### PR TITLE
Use different github runners architecture to build container images

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -19,7 +19,11 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
+
     permissions:
       contents: read
       packages: write
@@ -55,7 +59,6 @@ jobs:
           context: .
           push: ${{ github.event_name == 'push' && 'true' || 'false' }}
           sbom: ${{ github.event_name == 'push' && 'true' || 'false' }}
-          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
This PR speeds up the build of container images by 481%